### PR TITLE
Quarterly Bond Reporting Tab ETL

### DIFF
--- a/bond_data.py
+++ b/bond_data.py
@@ -70,7 +70,7 @@ def to_postgres(client, df, table):
         params = {"select": "*", "updated_at": f"lt.{time}", "order": "updated_at"}
         res = client.delete(resource=table, params=params)
     except Exception as e:
-        raise e
+        raise e.text
     return res
 
 

--- a/bond_tables.sql
+++ b/bond_tables.sql
@@ -105,4 +105,65 @@ CREATE TABLE api.all_bonds_aims_to_dashboard (
   "updated_at" timestamp
 );
 
+CREATE TABLE api.fdus_2020_bond (
+  "subproject_number" numeric,
+  "subproject_name" text,
+  "subproject_status" text,
+  "unit_code" text,
+  "unit_name" text,
+  "appropriated" numeric,
+  "updated_at" timestamp
+);
 
+
+CREATE TABLE api.subprojects_with_appropriations (
+  "subproject_number" numeric,
+  "subproject_name" text,
+  "subproject_appropriation" numeric,
+  "updated_at" timestamp
+);
+
+CREATE TABLE api.subprojects_with_budget (
+  "subproject_number" numeric,
+  "subproject_name" text,
+  "subproject_status" text,
+  "project_estimate" numeric,
+  "updated_at" timestamp
+);
+
+CREATE TABLE api.fdu_expenses_quarterly (
+  "fund" text,
+  "department" int,
+  "fiscal_quarter" text,
+  "fiscal_year" int,
+  "subproject_number" numeric,
+  "subproject_name" text,
+  "unit_code" text,
+  "unit_long_name" text,
+  "month-year" text,
+  "expenses" numeric,
+  "updated_at" timestamp
+);
+
+CREATE TABLE api.quarterly_spend_plan (
+  "unit_code" text,
+  "unit_name" text,
+  "fiscal_year" int,
+  "quarter" int,
+  "month" str,
+  "spend_plan" numeric,
+  "updated_at" timestamp
+);
+
+CREATE TABLE api.fdu_metadata_quarterly (
+  "subproject_number" numeric,
+  "subproject_name" text,
+  "subprogram_code" text,
+  "subprogram_long_name" text,
+  "program_code" text,
+  "program_long_name" text,
+  "unit_code" text,
+  "unit_long_name" text,
+  "appropriated" numeric,
+  "updated_at" timestamp
+);

--- a/config/csv_config.py
+++ b/config/csv_config.py
@@ -5,10 +5,14 @@ Configuration for the data sources of CSVs
 from pandera import Column, DataFrameSchema, Check
 
 # Microstrategy file names in S3
-# 2020 Bond Expenses Obligated.csv
 BOND_2020_EXP = "2020 Bond Expenses Obligated.csv"
-# All bonds Expenses Obligated.csv
 ALL_BONDS_EXP = "All bonds Expenses Obligated.csv"
+FDUS_2020 = "2020 FDUs with Subproject and Appropriation.csv"
+SUBPROJECT_APPRO = "Subprojects with total Appropriation.csv"
+SUBPROJECT_BUDGET = "Open Subprojects with Budget Estimate.csv"
+SUBPROJECT_BUDGET = "Open Subprojects with Budget Estimate.csv"
+FDU_EXPENSES = "FDU Expenses by Quarter.csv"
+FDU_METADATA = "2020 Division Group and Unit.csv"
 
 ## CSV Endpoints
 # Google Docs:
@@ -32,6 +36,8 @@ SPEND_PLAN_ALL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRhT8BEVrEMi3I
 BASELINE_SPEND_ALL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRhT8BEVrEMi3ISFPiz8ujKqmIkBgX9kvEQCdTU3eneG46cCr1-Cf1KJ5wovsej6gNPYx9UBEGN4VKi/pub?gid=0&single=true&output=csv"
 # 2020 Bond Program Name lookup Table
 BOND_PROG_NAMES = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSGZb6KRHwiSgxxsIrmxzDtEFR8Dg1QFfQ65dybwBv_EvZRCh3Fi1YqOP3vYI1uOe8M5ZZVFVuvUkZ-/pub?gid=215255456&single=true&output=csv"
+# Quarterly Spend Plan
+QUARTERLY_SPEND_PLAN = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSQCnILsJPgR7WqJgsOHobhQhVR5iZX4tzBeQi7AwWaBsflrpV5P1Lg0azwsiqqSVwLzRDfxe-gEgxP/pub?gid=0&single=true&output=csv"
 
 CSVS = [
     {
@@ -94,6 +100,135 @@ CSVS = [
                 "group_long_name": Column(str),
                 "obligated": Column(float),
                 "expenses": Column(float),
+            },
+            strict=True,
+        ),
+    },
+    {
+        "url": FDUS_2020,
+        "table": "fdus_2020_bond",
+        "date_field": False,
+        "boto3": True,
+        "field_maps": {
+            "Subproject@Number": "subproject_number",
+            "Subproject@Name": "subproject_name",
+            "Subproject@Status": "subproject_status",
+            "Unit@Unit Code": "unit_code",
+            "Unit@Long Name": "unit_name",
+            "Appropriated": "appropriated",
+        },
+        "schema": DataFrameSchema(
+            {
+                "subproject_number": Column(float),
+                "subproject_name": Column(str),
+                "subproject_status": Column(str),
+                "unit_code": Column(str),
+                "unit_name": Column(str),
+                "appropriated": Column(float),
+            },
+            strict=True,
+        ),
+    },
+    {
+        "url": SUBPROJECT_APPRO,
+        "table": "subprojects_with_appropriations",
+        "date_field": False,
+        "boto3": True,
+        "field_maps": {
+            "Subproject@Number": "subproject_number",
+            "Subproject@Name": "subproject_name",
+            "Budget": "subproject_appropriation",
+        },
+        "schema": DataFrameSchema(
+            {
+                "subproject_number": Column(float),
+                "subproject_name": Column(str),
+                "subproject_appropriation": Column(float),
+            },
+            strict=True,
+        ),
+    },
+    {
+        "url": SUBPROJECT_BUDGET,
+        "table": "subprojects_with_budget",
+        "date_field": False,
+        "boto3": True,
+        "field_maps": {
+            "Subproject@Number": "subproject_number",
+            "Subproject@Name": "subproject_name",
+            "Subproject@Status": "subproject_status",
+            "Current Budget Estimate Amount": "project_estimate",
+        },
+        "schema": DataFrameSchema(
+            {
+                "subproject_number": Column(float),
+                "subproject_name": Column(str),
+                "subproject_status": Column(str),
+                "project_estimate": Column(int),
+            },
+            strict=True,
+        ),
+    },
+    {
+        "url": FDU_EXPENSES,
+        "table": "fdu_expenses_quarterly",
+        "date_field": False,
+        "boto3": True,
+        "field_maps": {
+            "Fund": "fund",
+            "Department": "department",
+            "Fiscal Quarter@Name": "fiscal_quarter",
+            "Fiscal Quarter@Fiscal Year": "fiscal_year",
+            "Subproject@Number": "subproject_number",
+            "Subproject@Name": "subproject_name",
+            "Unit@Unit Code": "unit_code",
+            "Unit@Long Name": "unit_long_name",
+            "Fiscal Month-Fiscal Year": "month-year",
+            "Expenses": "expenses",
+        },
+        "schema": DataFrameSchema(
+            {
+                "fund": Column(str),
+                "department": Column(int),
+                "fiscal_quarter": Column(str),
+                "fiscal_year": Column(int),
+                "subproject_number": Column(float),
+                "subproject_name": Column(str),
+                "unit_code": Column(str),
+                "unit_long_name": Column(str),
+                "month-year": Column(str),
+                "expenses": Column(float),
+            },
+            strict=True,
+        ),
+    },
+    {
+        "url": FDU_METADATA,
+        "table": "fdu_metadata_quarterly",
+        "date_field": False,
+        "boto3": True,
+        "field_maps": {
+            "Subproject@Number": "subproject_number",
+            "Subproject@Name": "subproject_name",
+            "Group (As-Is)@Code": "subprogram_code",
+            "Group (As-Is)@Long Name": "subprogram_long_name",
+            "Division (As-Is)@Code": "program_code",
+            "Division (As-Is)@Long Name": "program_long_name",
+            "Unit@Unit Code": "unit_code",
+            "Unit@Long Name": "unit_long_name",
+            "Appropriated": "appropriated",
+        },
+        "schema": DataFrameSchema(
+            {
+                "subproject_number": Column(float),
+                "subproject_name": Column(str),
+                "subprogram_code": Column(str),
+                "subprogram_long_name": Column(str),
+                "program_code": Column(str),
+                "program_long_name": Column(str),
+                "unit_code": Column(str),
+                "unit_long_name": Column(str),
+                "appropriated": Column(float),
             },
             strict=True,
         ),
@@ -298,6 +433,31 @@ CSVS = [
                 "funding_amount": Column(int),
                 "program_sort": Column(int),
                 "sub_program_sort": Column(int),
+            },
+            strict=True,
+        ),
+    },
+    {
+        "url": QUARTERLY_SPEND_PLAN,
+        "table": "quarterly_spend_plan",
+        "date_field": False,
+        "boto3": False,
+        "field_maps": {
+            "Unit": "unit_code",
+            "Unit Name": "unit_name",
+            "Fiscal Year": "fiscal_year",
+            "Quarter": "quarter",
+            "Month": "month",
+            "Spend Plan": "spend_plan",
+        },
+        "schema": DataFrameSchema(
+            {
+                "unit_code": Column(str),
+                "unit_name": Column(str),
+                "fiscal_year": Column(int),
+                "quarter": Column(int),
+                "month": Column(str),
+                "spend_plan": Column(float),
             },
             strict=True,
         ),

--- a/config/csv_config.py
+++ b/config/csv_config.py
@@ -384,7 +384,7 @@ CSVS = [
             {
                 "dashboard_deptfundprogact": Column(str),
                 "fiscal_year": Column(int),
-                "amount": Column(int),
+                "amount": Column(float),
             },
             strict=True,
         ),

--- a/microstrategy_to_s3.py
+++ b/microstrategy_to_s3.py
@@ -22,10 +22,17 @@ BUCKET = os.getenv("BUCKET")
 REPORTS = {
     "2020 Bond Expenses Obligated": "85A9E0A049F06D98AF1CF3BE8CDA9394",
     "All bonds Expenses Obligated": "6B0DE57644C7C9912AAAE48392873233",
+    "2020 FDUs with Subproject and Appropriation": "97DE7BEFEE4C93C18FE27199BBBA00BF",
+    "Subprojects with total Appropriation": "01EF933E6D4FA79501CF10AF39DD8163",
+    "Open Subprojects with Budget Estimate": "E2AC0ACEF944222D0039DA9FF07BA05C",
+    "FDU Expenses by Quarter": "39EAC86D2F43664777ED6C9DBA27B43B",
+    "2020 Division Group and Unit": "221FEFD57C4B215CCB6BE2BD8DEE8CA9",
 }
 # To find report ID, go to the report in Microstrategy then:
 ## Go to Tools > Report Details Page or Document Details Page.
 ## Click Show Advanced Details button at the bottom
+# To view any of these reports in microstrategy (replace report_id):
+# https://coa-prod.cloud.microstrategy.com:443/MicroStrategy/servlet/mstrWeb?&src=4001&evt=4001&reportViewMode=1&reportID=report_id
 
 
 # Returns a connection object for interacting with the microstrategy API

--- a/quarterly_reporting.py
+++ b/quarterly_reporting.py
@@ -1,0 +1,270 @@
+import numpy as np
+import pandas as pd
+from pypgrest import Postgrest
+from sodapy import Socrata
+
+import os
+
+POSTGREST_ENDPOINT = os.getenv("POSTGREST_ENDPOINT")
+POSTGREST_TOKEN = os.getenv("POSTGREST_TOKEN")
+SO_WEB = os.getenv("SO_WEB")
+SO_TOKEN = os.getenv("SO_TOKEN")
+SO_KEY = os.getenv("SO_KEY")
+SO_SECRET = os.getenv("SO_SECRET")
+
+# Socrata dataset IDs
+SUBPROJECT_DATASET = os.getenv("SUBPROJECT_DATASET")
+FDU_DATASET = os.getenv("FDU_DATASET")
+EXPENSES_DATASET = os.getenv("EXPENSES_DATASET")
+
+SUBPROJECT_TABLES = [
+    "fdus_2020_bond",
+    "subprojects_with_appropriations",
+    "subprojects_with_budget",
+]
+EXPENSES = "fdu_expenses_quarterly"
+SPEND_PLAN = "quarterly_spend_plan"
+FDU_METADATA = "fdu_metadata_quarterly"
+
+
+
+FY_MONTHS = {
+    "OCT": "00",
+    "NOV": "01",
+    "DEC": "02",
+    "JAN": "03",
+    "FEB": "04",
+    "MAR": "05",
+    "APR": "06",
+    "MAY": "07",
+    "JUN": "08",
+    "JUL": "09",
+    "AUG": "10",
+    "SEP": "11",
+    "P13": "11",  # Putting period 13 in September
+}
+
+FY_MONTH_DECODED = {
+    "00": "October",
+    "01": "November",
+    "02": "December",
+    "03": "January",
+    "04": "February",
+    "05": "March",
+    "06": "April",
+    "07": "May",
+    "08": "June",
+    "09": "July",
+    "10": "August",
+    "11": "September",
+}
+FY_MONTH_DECODED_INVERSE = {v: k for k, v in FY_MONTH_DECODED.items()}
+
+
+def get_data(client, table):
+    """
+    Gets all data from postgrest endpoint and returns it as a dataframe.
+    """
+    params = {
+        "select": "*",
+        "order": "updated_at",
+    }
+    return pd.DataFrame(client.select(resource=table, params=params))
+
+
+def subproject_transformation(client):
+    """
+    Combines subproject reports into one dataframe
+    Parameters
+    ----------
+    client: Postgrest client
+
+    Returns
+    -------
+    df of combined subproject reports
+
+    """
+
+    df = get_data(client, SUBPROJECT_TABLES[0])
+    df = df.set_index("subproject_number")
+    # Merge the rest into the starter df
+    for table in SUBPROJECT_TABLES[1:3]:
+        df2 = pd.DataFrame(get_data(client, table))
+        df2 = df2.set_index("subproject_number")
+        cols_to_use = df2.columns.difference(df.columns)
+        df = df.merge(df2[cols_to_use], left_index=True, right_index=True, how="left")
+
+    return df
+
+
+def create_fdu_metadata_table(client):
+    """
+    Returns a df with the metadata for each FDU/subproject, with some transformations.
+    """
+
+    # Formatting metadata table
+    metadata = pd.DataFrame(get_data(client, FDU_METADATA))
+    # For bikeways group all subprograms together
+    metadata["subprogram_long_name"] = np.where(
+        metadata["program_code"] == "D001",
+        metadata["program_long_name"],
+        metadata["subprogram_long_name"],
+    )
+    # If ZZZZ for subprogram, use the program code as well
+    metadata["subprogram_long_name"] = np.where(
+        metadata["subprogram_code"] == "ZZZZ",
+        metadata["program_long_name"],
+        metadata["subprogram_long_name"],
+    )
+    return metadata
+
+
+def create_month_col(row):
+    # Gets the fiscal month of the row and the FY and concatenates them
+    return f"{row['fiscal_year']}{FY_MONTHS[row['month-year'][0:3]]}"
+
+
+def select_quarter(row, quarter):
+    # Sets "fy-quarter" to the month_col for the selected quarter and everything else to zero.
+    if row["fy-quarter"] == quarter:
+        return row["month_col"]
+    return "0"
+
+
+def decode_months(row):
+    # Returns the name of the month based on the month_col
+    if row["month_col"] == "0":
+        return "Prior Spend"
+    return FY_MONTH_DECODED[row["month_col"][-2:]]
+
+
+def encode_months(row):
+    # encodes month to the numeric fiscal month value
+    return FY_MONTH_DECODED_INVERSE[row["month"]]
+
+
+def to_output(df, spend):
+    # Prepares the df for export by appending the spend plan info and calculating cumulative totals
+    df = pd.melt(
+        df.reset_index(),
+        id_vars="unit_code",
+        var_name="month_col",
+        value_name="expenses",
+    )
+    df = pd.merge(df, spend, on=["unit_code", "month_col"], how="left")
+    df["Month Name"] = df.apply(decode_months, axis=1)
+    df["spend_plan"] = np.where(
+        df["Month Name"] == "Prior Spend", df["expenses"], df["spend_plan"]
+    )
+
+    # Cumulative totals
+    quarter = df[df["month_col"] != "0"]
+    quarter = quarter.set_index("month_col")
+    quarter = quarter.sort_index()
+    quarter["sum_expenses"] = quarter.groupby(["unit_code"])["expenses"].cumsum()
+    quarter["sum_planned"] = quarter.groupby(["unit_code"])["spend_plan"].cumsum()
+    quarter = quarter.reset_index()
+
+    df = df[df["month_col"] == "0"]
+    df = df.append(quarter)
+
+    return df
+
+def df_to_socrata(soda, df, dataset_id, include_index):
+    if include_index:
+        df = df.reset_index()
+    df = df.replace({np.nan: None})
+    payload = df.to_dict(orient="records")
+    try:
+        res = soda.replace(dataset_id, payload)
+    except Exception as e:
+        raise e
+
+
+def main():
+    # Postgrest client log in
+    client = Postgrest(
+        POSTGREST_ENDPOINT,
+        token=POSTGREST_TOKEN,
+        headers={"Prefer": "return=representation"},
+    )
+    # Socrata client log in
+    soda = Socrata(SO_WEB, SO_TOKEN, username=SO_KEY, password=SO_SECRET, timeout=500, )
+
+    # Download & transform subproject reports
+    subprojects = subproject_transformation(client)
+    df_to_socrata(soda, subprojects, SUBPROJECT_DATASET, True)
+
+    # Download & transform subproject reports
+    metadata = create_fdu_metadata_table(client)
+    df_to_socrata(soda, metadata, FDU_DATASET, False)
+
+
+    exp = get_data(client, EXPENSES)
+    exp["month_col"] = exp.apply(create_month_col, axis=1)
+    exp = pd.pivot_table(
+        exp, index="unit_code", columns="month_col", values="expenses", aggfunc="sum"
+    )
+    exp = exp.fillna(0)
+    exp = pd.melt(
+        exp.reset_index(),
+        id_vars="unit_code",
+        var_name="month_col",
+        value_name="expenses",
+    )
+
+    exp["quarter"] = exp["month_col"].str[-2:].astype(int) // 3 + 1
+    exp["fiscal_year"] = exp["month_col"].str[:4].astype(int)
+    exp["fy-quarter"] = exp["fiscal_year"].astype(str) + exp["quarter"].astype(str)
+    curr_quarter = exp["fy-quarter"].max()
+    exp["curr_quarter"] = exp.apply(select_quarter, axis=1, args=[curr_quarter])
+
+    if int(curr_quarter[-1:]) > 1:
+        prev_quarter = f"{curr_quarter[:4]}{int(curr_quarter[-1:]) - 1}"
+    else:
+        prev_quarter = f"{int(curr_quarter[:4]) - 1}{3}"
+
+    prev_exp = exp[exp["fy-quarter"] <= prev_quarter]
+
+    exp = pd.pivot_table(
+        exp, index="unit_code", columns="curr_quarter", values="expenses", aggfunc="sum"
+    )
+    # Adding missing months from selected quarter
+    if len(exp.columns) < 4:
+        for m in range(4 - len(exp.columns)):
+            latest_month = exp.columns.max()
+            added_month = str(int(latest_month[-2:]) + 1)
+            if len(added_month) == 1:
+                exp[f"{latest_month[:-2]}0{added_month}"] = 0
+            else:
+                exp[f"{latest_month[:-2]}{added_month}"] = 0
+
+    prev_exp["prev_quarter"] = prev_exp.apply(
+        select_quarter, axis=1, args=[prev_quarter]
+    )
+    prev_exp = pd.pivot_table(
+        prev_exp,
+        index="unit_code",
+        columns="prev_quarter",
+        values="expenses",
+        aggfunc="sum",
+    )
+
+    spend_plan = get_data(client, SPEND_PLAN)
+    spend_plan["month_no"] = spend_plan.apply(encode_months, axis=1)
+    spend_plan["month_col"] = (
+        spend_plan["fiscal_year"].astype(str) + spend_plan["month_no"]
+    )
+
+    exp = to_output(exp, spend_plan)
+    exp["quarter_selection"] = f"{curr_quarter[:4]} Q{curr_quarter[-1:]}"
+    prev_exp = to_output(prev_exp, spend_plan)
+    prev_exp["quarter_selection"] = f"{prev_quarter[:4]} Q{prev_quarter[-1:]}"
+
+    output = exp.append(prev_exp)
+
+    df_to_socrata(soda, output, EXPENSES_DATASET, False)
+
+
+if __name__ == "__main__":
+    main()

--- a/quarterly_reporting.py
+++ b/quarterly_reporting.py
@@ -159,6 +159,7 @@ def to_output(df, spend):
 
     # Cumulative totals
     quarter = df[df["month_col"] != "0"]
+    quarter["spend_plan"] = quarter["spend_plan"].fillna(0)
     quarter = quarter.set_index("month_col")
     quarter = quarter.sort_index()
     quarter["sum_expenses"] = quarter.groupby(["unit_code"])["expenses"].cumsum()


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/11669

This ETL feeds data into three new datasets for this new quarterly bond reporting tab:
- [FDU metadata](https://datahub.austintexas.gov/dataset/2020-Bond-Dashboard-FDU-Metadata/x2us-mcf7) is used to filter down the next two data by the program/subprogram level.
- [Expenses and Spend Plan by Quarter](https://datahub.austintexas.gov/dataset/2020-Bond-Dashboard-Expenses-and-Spend-Plan-by-Qua/cpw3-9e8n) is just the expenses and spend plan for each unit by month/quarter.
- [Subproject appropriation and budget](https://datahub.austintexas.gov/dataset/2020-Bond-Dashboard-Subproject-Appropriation-and-B/e3b7-kndw).

Power BI tabs:
- [Quarterly Expenses](https://app.powerbigov.us/links/JEoSaXVmsi?ctid=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f&pbi_source=linkShare&bookmarkGuid=6a41a476-0f29-45b0-b334-62a767cc84eb)
- [Subprojects](https://app.powerbigov.us/links/JEoSaXVmsi?ctid=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f&pbi_source=linkShare&bookmarkGuid=8e00d158-c65e-4609-b27e-7ed652565dde)

The ETL picks the top two most recent quarters based on the newest expense date. So if the most recent expense is on October 10th, 2023, we'd be in Q1 2024. So this ETL would return the expenses summarized for Q1 2024 and Q4 2023. This is in the column called `quarter_selection` for both subprojects and units.



